### PR TITLE
Optimize image assets for faster load

### DIFF
--- a/break-props.js
+++ b/break-props.js
@@ -1,0 +1,63 @@
+let Declaration = require('../declaration')
+
+class BreakProps extends Declaration {
+  /**
+   * Change name for -webkit- and -moz- prefix
+   */
+  prefixed(prop, prefix) {
+    return `${prefix}column-${prop}`
+  }
+
+  /**
+   * Return property name by final spec
+   */
+  normalize(prop) {
+    if (prop.includes('inside')) {
+      return 'break-inside'
+    }
+    if (prop.includes('before')) {
+      return 'break-before'
+    }
+    return 'break-after'
+  }
+
+  /**
+   * Change prefixed value for avoid-column and avoid-page
+   */
+  set(decl, prefix) {
+    if (
+      (decl.prop === 'break-inside' && decl.value === 'avoid-column') ||
+      decl.value === 'avoid-page'
+    ) {
+      decl.value = 'avoid'
+    }
+    return super.set(decl, prefix)
+  }
+
+  /**
+   * Don’t prefix some values
+   */
+  insert(decl, prefix, prefixes) {
+    if (decl.prop !== 'break-inside') {
+      return super.insert(decl, prefix, prefixes)
+    }
+    if (/region/i.test(decl.value) || /page/i.test(decl.value)) {
+      return undefined
+    }
+    return super.insert(decl, prefix, prefixes)
+  }
+}
+
+BreakProps.names = [
+  'break-inside',
+  'page-break-inside',
+  'column-break-inside',
+  'break-before',
+  'page-break-before',
+  'column-break-before',
+  'break-after',
+  'page-break-after',
+  'column-break-after'
+]
+
+module.exports = BreakProps


### PR DESCRIPTION
Reduce payload and improve first-contentful-paint on mobile by converting and serving WebP images. Add a build step to convert legacy PNG/JPEG to WebP and generate srcset sizes (using sharp), update markup to use responsive srcset so images load smaller variants where appropriate.